### PR TITLE
Can create AHTabBarController without storyboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,22 @@
-# CocoaPods
-#
-# We recommend against adding the Pods directory to your .gitignore. However
-# you should judge for yourself, the pros and cons are mentioned at:
-# http://guides.cocoapods.org/using/using-cocoapods.html#should-i-ignore-the-pods-directory-in-source-control?
-#
-# Pods/
+# https://github.com/github/gitignore/blob/master/Objective-C.gitignore
 
+# OS X
+.DS_Store
+
+# Xcode
+build/
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata
+*.xccheckout
+profile
+*.moved-aside
+DerivedData
+*.hmap
+*.ipa

--- a/AHTabBarController.xcodeproj/project.pbxproj
+++ b/AHTabBarController.xcodeproj/project.pbxproj
@@ -15,7 +15,7 @@
 		8ECEA95019966F5C006FB7AA /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 8ECEA94F19966F5C006FB7AA /* main.m */; };
 		8ECEA95419966F5C006FB7AA /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 8ECEA95319966F5C006FB7AA /* AppDelegate.m */; };
 		8ECEA95719966F5C006FB7AA /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8ECEA95519966F5C006FB7AA /* Main.storyboard */; };
-		8ECEA95A19966F5C006FB7AA /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 8ECEA95919966F5C006FB7AA /* ViewController.m */; };
+		8ECEA95A19966F5C006FB7AA /* AHExampleViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 8ECEA95919966F5C006FB7AA /* AHExampleViewController.m */; };
 		8ECEA95C19966F5C006FB7AA /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8ECEA95B19966F5C006FB7AA /* Images.xcassets */; };
 		8ECEA96319966F5C006FB7AA /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8ECEA96219966F5C006FB7AA /* XCTest.framework */; };
 		8ECEA96419966F5C006FB7AA /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8ECEA94319966F5C006FB7AA /* Foundation.framework */; };
@@ -26,6 +26,9 @@
 		8ECEA98019966FA6006FB7AA /* AHTabBarController.m in Sources */ = {isa = PBXBuildFile; fileRef = 8ECEA97C19966FA6006FB7AA /* AHTabBarController.m */; };
 		8ECEA98119966FA6006FB7AA /* AHTabView.m in Sources */ = {isa = PBXBuildFile; fileRef = 8ECEA97E19966FA6006FB7AA /* AHTabView.m */; };
 		8EE79C94199671310049F3F3 /* UIImage+Overlay.m in Sources */ = {isa = PBXBuildFile; fileRef = 8EE79C93199671310049F3F3 /* UIImage+Overlay.m */; };
+		D85D4E031CE3A12B00DACB18 /* AHStoryboardExampleViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = D85D4E021CE3A12B00DACB18 /* AHStoryboardExampleViewController.m */; };
+		D85D4E061CE3A37100DACB18 /* AHExampleListViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = D85D4E051CE3A37100DACB18 /* AHExampleListViewController.m */; };
+		D85D4E091CE42F6600DACB18 /* AHCodeExampleViewcontroller.m in Sources */ = {isa = PBXBuildFile; fileRef = D85D4E081CE42F6600DACB18 /* AHCodeExampleViewcontroller.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -51,8 +54,8 @@
 		8ECEA95219966F5C006FB7AA /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		8ECEA95319966F5C006FB7AA /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
 		8ECEA95619966F5C006FB7AA /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
-		8ECEA95819966F5C006FB7AA /* ViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ViewController.h; sourceTree = "<group>"; };
-		8ECEA95919966F5C006FB7AA /* ViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ViewController.m; sourceTree = "<group>"; };
+		8ECEA95819966F5C006FB7AA /* AHExampleViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AHExampleViewController.h; sourceTree = "<group>"; };
+		8ECEA95919966F5C006FB7AA /* AHExampleViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AHExampleViewController.m; sourceTree = "<group>"; };
 		8ECEA95B19966F5C006FB7AA /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		8ECEA96119966F5C006FB7AA /* AHTabBarControllerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AHTabBarControllerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		8ECEA96219966F5C006FB7AA /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
@@ -67,6 +70,12 @@
 		8ECEA97E19966FA6006FB7AA /* AHTabView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AHTabView.m; path = AHTabBarController/AHTabView.m; sourceTree = "<group>"; };
 		8EE79C92199671310049F3F3 /* UIImage+Overlay.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "UIImage+Overlay.h"; path = "AHTabBarController/Category/UIImage+Overlay.h"; sourceTree = "<group>"; };
 		8EE79C93199671310049F3F3 /* UIImage+Overlay.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "UIImage+Overlay.m"; path = "AHTabBarController/Category/UIImage+Overlay.m"; sourceTree = "<group>"; };
+		D85D4E011CE3A12B00DACB18 /* AHStoryboardExampleViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AHStoryboardExampleViewController.h; sourceTree = "<group>"; };
+		D85D4E021CE3A12B00DACB18 /* AHStoryboardExampleViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AHStoryboardExampleViewController.m; sourceTree = "<group>"; };
+		D85D4E041CE3A37100DACB18 /* AHExampleListViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AHExampleListViewController.h; sourceTree = "<group>"; };
+		D85D4E051CE3A37100DACB18 /* AHExampleListViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AHExampleListViewController.m; sourceTree = "<group>"; };
+		D85D4E071CE42F6500DACB18 /* AHCodeExampleViewcontroller.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AHCodeExampleViewcontroller.h; sourceTree = "<group>"; };
+		D85D4E081CE42F6600DACB18 /* AHCodeExampleViewcontroller.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AHCodeExampleViewcontroller.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -96,7 +105,8 @@
 		8ECEA93719966F5C006FB7AA = {
 			isa = PBXGroup;
 			children = (
-				8ECEA94919966F5C006FB7AA /* AHTabBarController */,
+				8ECEA94919966F5C006FB7AA /* AHTabBarControllerExample */,
+				8ECEA97819966F7E006FB7AA /* AHTabBarController */,
 				8ECEA96819966F5C006FB7AA /* AHTabBarControllerTests */,
 				8ECEA94219966F5C006FB7AA /* Frameworks */,
 				8ECEA94119966F5C006FB7AA /* Products */,
@@ -123,18 +133,24 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		8ECEA94919966F5C006FB7AA /* AHTabBarController */ = {
+		8ECEA94919966F5C006FB7AA /* AHTabBarControllerExample */ = {
 			isa = PBXGroup;
 			children = (
-				8ECEA97819966F7E006FB7AA /* AHTabBarController */,
 				8ECEA95219966F5C006FB7AA /* AppDelegate.h */,
 				8ECEA95319966F5C006FB7AA /* AppDelegate.m */,
+				D85D4E041CE3A37100DACB18 /* AHExampleListViewController.h */,
+				D85D4E051CE3A37100DACB18 /* AHExampleListViewController.m */,
+				D85D4E011CE3A12B00DACB18 /* AHStoryboardExampleViewController.h */,
+				D85D4E021CE3A12B00DACB18 /* AHStoryboardExampleViewController.m */,
+				D85D4E071CE42F6500DACB18 /* AHCodeExampleViewcontroller.h */,
+				D85D4E081CE42F6600DACB18 /* AHCodeExampleViewcontroller.m */,
+				8ECEA95819966F5C006FB7AA /* AHExampleViewController.h */,
+				8ECEA95919966F5C006FB7AA /* AHExampleViewController.m */,
 				8ECEA95519966F5C006FB7AA /* Main.storyboard */,
-				8ECEA95819966F5C006FB7AA /* ViewController.h */,
-				8ECEA95919966F5C006FB7AA /* ViewController.m */,
 				8ECEA95B19966F5C006FB7AA /* Images.xcassets */,
 				8ECEA94A19966F5C006FB7AA /* Supporting Files */,
 			);
+			name = AHTabBarControllerExample;
 			path = AHTabBarController;
 			sourceTree = "<group>";
 		};
@@ -179,7 +195,7 @@
 				8ECEA97919966FA6006FB7AA /* AHSubitemView.h */,
 				8ECEA97A19966FA6006FB7AA /* AHSubitemView.m */,
 			);
-			name = AHTabBarController;
+			path = AHTabBarController;
 			sourceTree = "<group>";
 		};
 		8EE79C911996711C0049F3F3 /* Category */ = {
@@ -289,13 +305,16 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D85D4E031CE3A12B00DACB18 /* AHStoryboardExampleViewController.m in Sources */,
 				8ECEA97F19966FA6006FB7AA /* AHSubitemView.m in Sources */,
-				8ECEA95A19966F5C006FB7AA /* ViewController.m in Sources */,
+				8ECEA95A19966F5C006FB7AA /* AHExampleViewController.m in Sources */,
+				D85D4E091CE42F6600DACB18 /* AHCodeExampleViewcontroller.m in Sources */,
 				8ECEA98019966FA6006FB7AA /* AHTabBarController.m in Sources */,
 				8ECEA95419966F5C006FB7AA /* AppDelegate.m in Sources */,
 				8EE79C94199671310049F3F3 /* UIImage+Overlay.m in Sources */,
 				8ECEA98119966FA6006FB7AA /* AHTabView.m in Sources */,
 				8ECEA95019966F5C006FB7AA /* main.m in Sources */,
+				D85D4E061CE3A37100DACB18 /* AHExampleListViewController.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AHTabBarController/AHCodeExampleViewcontroller.h
+++ b/AHTabBarController/AHCodeExampleViewcontroller.h
@@ -1,0 +1,13 @@
+//
+//  AHCodeExampleViewcontroller.h
+//  AHTabBarController
+//
+//  Created by Joe on 5/11/16.
+//  Copyright © 2016 Arthur Hemmer. All rights reserved.
+//
+
+#import "AHTabBarController.h"
+
+@interface AHCodeExampleViewcontroller : AHTabBarController
+
+@end

--- a/AHTabBarController/AHCodeExampleViewcontroller.m
+++ b/AHTabBarController/AHCodeExampleViewcontroller.m
@@ -1,0 +1,93 @@
+//
+//  AHCodeExampleViewcontroller.m
+//  AHTabBarController
+//
+//  Created by Joe on 5/11/16.
+//  Copyright © 2016 Arthur Hemmer. All rights reserved.
+//
+
+#import "AHCodeExampleViewcontroller.h"
+
+@implementation AHCodeExampleViewcontroller
+
+- (void)loadView {
+    [super loadView];
+    
+    /******* PURUS *******/
+    AHTabView *purus = [AHTabView new];
+    [purus setImage:[UIImage imageNamed:@"persondot"]];
+    [purus setTitle:@"Purus"];
+    
+    AHSubitemView *pFirst = [AHSubitemView new];
+    [pFirst setImage:[UIImage imageNamed:@"persondot"]];
+    [pFirst setTitle:@"First"];
+    [purus addSubitem:pFirst];
+    
+    AHSubitemView *pSecond = [AHSubitemView new];
+    [pSecond setImage:[UIImage imageNamed:@"newspaper"]];
+    [pSecond setTitle:@"Second"];
+    [purus addSubitem:pSecond];
+    
+    /******* FRINGILLA *******/
+    AHTabView *fringilla = [AHTabView new];
+    [fringilla setImage:[UIImage imageNamed:@"receipt"]];
+    [fringilla setTitle:@"Fringilla"];
+    
+    AHSubitemView *fFirst = [AHSubitemView new];
+    [fFirst setImage:[UIImage imageNamed:@"photos"]];
+    [fFirst setTitle:@"First"];
+    [fringilla addSubitem:fFirst];
+    
+    AHSubitemView *fSecond = [AHSubitemView new];
+    [fSecond setImage:[UIImage imageNamed:@"tv"]];
+    [fSecond setTitle:@"Second"];
+    [fringilla addSubitem:fSecond];
+    
+    AHSubitemView *fThird = [AHSubitemView new];
+    [fThird setImage:[UIImage imageNamed:@"user"]];
+    [fThird setTitle:@"Third"];
+    [fringilla addSubitem:fThird];
+    
+    /******* IPSUM *******/
+    AHTabView *ipsum = [AHTabView new];
+    [ipsum setImage:[UIImage imageNamed:@"user"]];
+    [ipsum setTitle:@"Ipsum"];
+    
+    AHSubitemView *iFirst = [AHSubitemView new];
+    [iFirst setImage:[UIImage imageNamed:@"photos"]];
+    [iFirst setTitle:@"First"];
+    [ipsum addSubitem:iFirst];
+    
+    //Don't forget to add your AHTabView instances to the AHTabBarController!
+    [self.tabs addObjectsFromArray:@[purus, fringilla, ipsum]];
+}
+
+-(UIViewController*)viewControllerForSubItem:(AHSubitemView*)subItem
+{
+    UIViewController *vc = [[UIViewController alloc] init];
+    vc.view.backgroundColor = [UIColor whiteColor];
+    UILabel *label = [[UILabel alloc] initWithFrame:CGRectMake(20, 100, 200, 30)];
+    [vc.view addSubview:label];
+    
+    if (subItem.tabIndex == 0) {
+        if (subItem.subIndex == 0) {
+            label.text = @"Purus One";
+        } else if (subItem.subIndex == 1) {
+            label.text = @"Purus Two";
+        }
+    } else if (subItem.tabIndex == 1) {
+        if (subItem.subIndex == 0) {
+            label.text = @"Fringilla One";
+        } else if (subItem.subIndex == 1) {
+            label.text = @"Fringilla Two";
+        } else if (subItem.subIndex == 2) {
+            label.text = @"Fringilla Three";
+        }
+    } else if (subItem.tabIndex == 2) {
+        label.text = @"Ipsum";
+    }
+    
+    return vc;
+}
+
+@end

--- a/AHTabBarController/AHExampleListViewController.h
+++ b/AHTabBarController/AHExampleListViewController.h
@@ -1,0 +1,13 @@
+//
+//  AHExampleListViewController.h
+//  AHTabBarController
+//
+//  Created by Joe on 5/11/16.
+//  Copyright © 2016 Arthur Hemmer. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface AHExampleListViewController : UITableViewController
+
+@end

--- a/AHTabBarController/AHExampleListViewController.m
+++ b/AHTabBarController/AHExampleListViewController.m
@@ -1,0 +1,60 @@
+//
+//  AHExampleListViewController.m
+//  AHTabBarController
+//
+//  Created by Joe on 5/11/16.
+//  Copyright © 2016 Arthur Hemmer. All rights reserved.
+//
+
+#import "AHExampleListViewController.h"
+#import "AHStoryboardExampleViewController.h"
+#import "AHCodeExampleViewcontroller.h"
+#import "AHExampleViewController.h"
+
+@implementation AHExampleListViewController
+
+- (void)loadView {
+    [super loadView];
+    self.title = @"AHTabBar Examples";
+}
+
+- (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView {
+    return 1;
+}
+
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
+    return 2;
+}
+
+- (UITableViewCell *)tableView:(UITableView *)tableView
+         cellForRowAtIndexPath:(NSIndexPath *)indexPath {
+    
+    UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"cell"];
+    if (cell == nil) {
+        cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault
+                                      reuseIdentifier:@"cell"];
+    }
+    
+    if (indexPath.row == 0) {
+        cell.textLabel.text = @"Storyboard Example";
+    }
+    else if (indexPath.row == 1) {
+        cell.textLabel.text = @"Code Only Example";
+    }
+    
+    return cell;
+}
+
+- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
+    if (indexPath.row == 0) {
+        AHTabBarController *vc = [AHStoryboardExampleViewController controller];
+        [AHExampleViewController setTabController:vc];
+        [self.navigationController pushViewController:vc animated:true];
+    }
+    else if (indexPath.row == 1) {
+        UIViewController *vc = [[AHCodeExampleViewcontroller alloc] init];
+        [self.navigationController pushViewController:vc animated:true];
+    }
+}
+
+@end

--- a/AHTabBarController/AHExampleViewController.h
+++ b/AHTabBarController/AHExampleViewController.h
@@ -8,6 +8,10 @@
 
 #import <UIKit/UIKit.h>
 
-@interface ViewController : UIViewController
+@class AHTabBarController;
+
+@interface AHExampleViewController : UIViewController
+
++(void)setTabController:(AHTabBarController*)tabController;
 
 @end

--- a/AHTabBarController/AHExampleViewController.m
+++ b/AHTabBarController/AHExampleViewController.m
@@ -6,29 +6,34 @@
 //  Copyright (c) 2014 Arthur Hemmer. All rights reserved.
 //
 
-#import "ViewController.h"
-
+#import "AHExampleViewController.h"
 #import "AHTabBarController.h"
-#import "AppDelegate.h"
 
-@interface ViewController ()
+static AHTabBarController *_tabController;
+
+@interface AHExampleViewController ()
 
 @property (nonatomic, weak) IBOutlet UIButton *btnHideBar;
 -(IBAction)btnHideBarPressed:(UIButton*)sender;
 
 @end
 
-@implementation ViewController
+@implementation AHExampleViewController
+
++(void)setTabController:(AHTabBarController*)tabController {
+    _tabController = tabController;
+}
 
 -(IBAction)btnHideBarPressed:(UIButton *)sender
 {
-    AppDelegate *delegate = [[UIApplication sharedApplication] delegate];
-    AHTabBarController *tabBarController = (AHTabBarController*)delegate.window.rootViewController;
+    if (_tabController == nil) {
+        return;
+    }
     
-    if (tabBarController.isTabBarHidden)
-        [tabBarController presentTabBar];
+    if (_tabController.isTabBarHidden)
+        [_tabController presentTabBar];
     else
-        [tabBarController hideTabBar];
+        [_tabController hideTabBar];
 }
 
 - (void)viewDidLoad

--- a/AHTabBarController/AHStoryboardExampleViewController.h
+++ b/AHTabBarController/AHStoryboardExampleViewController.h
@@ -1,0 +1,15 @@
+//
+//  StoryboardExampleViewController.h
+//  AHTabBarController
+//
+//  Created by Joe on 5/11/16.
+//  Copyright © 2016 Arthur Hemmer. All rights reserved.
+//
+
+#import "AHTabBarController.h"
+
+@interface AHStoryboardExampleViewController : AHTabBarController
+
++ (AHStoryboardExampleViewController*)controller;
+
+@end

--- a/AHTabBarController/AHStoryboardExampleViewController.m
+++ b/AHTabBarController/AHStoryboardExampleViewController.m
@@ -1,0 +1,79 @@
+//
+//  StoryboardExampleViewController.m
+//  AHTabBarController
+//
+//  Created by Joe on 5/11/16.
+//  Copyright © 2016 Arthur Hemmer. All rights reserved.
+//
+
+#import "AHStoryboardExampleViewController.h"
+#import "AHTabBarController.h"
+
+@implementation AHStoryboardExampleViewController
+
++ (AHStoryboardExampleViewController*)controller {
+    UIStoryboard *sb = [UIStoryboard storyboardWithName:@"Main" bundle:nil];
+    AHStoryboardExampleViewController *vc = [sb instantiateViewControllerWithIdentifier:
+                                             @"AHStoryboardExampleViewController"];
+    return vc;
+}
+
+- (void)loadView {
+    [super loadView];
+    
+    /******* PURUS *******/
+    AHTabView *purus = [AHTabView new];
+    [purus setImage:[UIImage imageNamed:@"persondot"]];
+    [purus setTitle:@"Purus"];
+    
+    AHSubitemView *pFirst = [AHSubitemView new];
+    [pFirst setImage:[UIImage imageNamed:@"persondot"]];
+    [pFirst setTitle:@"First"];
+    [pFirst setViewControllerIdentifier:@"PurusFirst"];
+    [purus addSubitem:pFirst];
+    
+    AHSubitemView *pSecond = [AHSubitemView new];
+    [pSecond setImage:[UIImage imageNamed:@"newspaper"]];
+    [pSecond setTitle:@"Second"];
+    [pSecond setViewControllerIdentifier:@"PurusSecond"];
+    [purus addSubitem:pSecond];
+    
+    /******* FRINGILLA *******/
+    AHTabView *fringilla = [AHTabView new];
+    [fringilla setImage:[UIImage imageNamed:@"receipt"]];
+    [fringilla setTitle:@"Fringilla"];
+    
+    AHSubitemView *fFirst = [AHSubitemView new];
+    [fFirst setImage:[UIImage imageNamed:@"photos"]];
+    [fFirst setTitle:@"First"];
+    [fFirst setViewControllerIdentifier:@"FringillaFirst"];
+    [fringilla addSubitem:fFirst];
+    
+    AHSubitemView *fSecond = [AHSubitemView new];
+    [fSecond setImage:[UIImage imageNamed:@"tv"]];
+    [fSecond setTitle:@"Second"];
+    [fSecond setViewControllerIdentifier:@"FringillaSecond"];
+    [fringilla addSubitem:fSecond];
+    
+    AHSubitemView *fThird = [AHSubitemView new];
+    [fThird setImage:[UIImage imageNamed:@"user"]];
+    [fThird setTitle:@"Third"];
+    [fThird setViewControllerIdentifier:@"FringillaThird"];
+    [fringilla addSubitem:fThird];
+    
+    /******* IPSUM *******/
+    AHTabView *ipsum = [AHTabView new];
+    [ipsum setImage:[UIImage imageNamed:@"user"]];
+    [ipsum setTitle:@"Ipsum"];
+    
+    AHSubitemView *iFirst = [AHSubitemView new];
+    [iFirst setImage:[UIImage imageNamed:@"photos"]];
+    [iFirst setTitle:@"First"];
+    [iFirst setViewControllerIdentifier:@"IpsumFirst"];
+    [ipsum addSubitem:iFirst];
+    
+    //Don't forget to add your AHTabView instances to the AHTabBarController!
+    [self.tabs addObjectsFromArray:@[purus, fringilla, ipsum]];
+}
+
+@end

--- a/AHTabBarController/AHTabBarController-Info.plist
+++ b/AHTabBarController/AHTabBarController-Info.plist
@@ -26,8 +26,6 @@
 	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>Launch Screen</string>
-	<key>UIMainStoryboardFile</key>
-	<string>Main</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>

--- a/AHTabBarController/AHTabBarController/AHSubitemView.h
+++ b/AHTabBarController/AHTabBarController/AHSubitemView.h
@@ -42,6 +42,9 @@
  */
 @property (nonatomic) AHTabView *tab;
 
+@property (nonatomic, assign) NSInteger tabIndex;
+@property (nonatomic, assign) NSInteger subIndex;
+
 /**
  Animate to a selected/deselected state.
  */

--- a/AHTabBarController/AHTabBarController/AHTabBarController.m
+++ b/AHTabBarController/AHTabBarController/AHTabBarController.m
@@ -191,13 +191,19 @@
     }];
 }
 
+-(UIViewController*)viewControllerForSubItem:(AHSubitemView*)subItem
+{
+    return [self.storyboard instantiateViewControllerWithIdentifier:
+            subItem.viewControllerIdentifier];
+}
+
 -(void)reloadViewForItem:(AHSubitemView *)subitem
 {
     if (!subitem)
         return;
     
     //Removing the old view(controller)
-    UIViewController *oldController = [self viewControllerForSubitem:self.currentItem];
+    UIViewController *oldController = [self loadedViewControllerForSubitem:self.currentItem];
     if (oldController && ![oldController isEqual:[NSNull null]]) {
         [oldController.view removeFromSuperview];
         [oldController willMoveToParentViewController:nil];
@@ -205,9 +211,12 @@
     }
     
     //Getting the new viewcontroller or create it if we don't have it in memory yet
-    UIViewController *viewController = [self viewControllerForSubitem:subitem];
+    UIViewController *viewController = [self loadedViewControllerForSubitem:subitem];
     if ([viewController isEqual:[NSNull null]] || !viewController) {
-        viewController = [self.storyboard instantiateViewControllerWithIdentifier:subitem.viewControllerIdentifier];
+        subitem.tabIndex = [self.tabs indexOfObject:subitem.tab];
+        subitem.subIndex = [subitem.tab.subitems indexOfObject:subitem];
+        
+        viewController = [self viewControllerForSubItem:subitem];
         
         if (!viewController) {
             [[NSException exceptionWithName:@"Invalid ViewController!"
@@ -294,7 +303,7 @@
 #pragma mark - Utility
 //A method that gets the viewcontroller from the rootViewControllers array for the
 // given subitem. If the viewController does not exist it will return an [NSNull null]
--(UIViewController*)viewControllerForSubitem:(AHSubitemView*)subitem
+-(UIViewController*)loadedViewControllerForSubitem:(AHSubitemView*)subitem
 {
     if (!subitem)
         return nil;

--- a/AHTabBarController/AppDelegate.m
+++ b/AHTabBarController/AppDelegate.m
@@ -7,74 +7,21 @@
 //
 
 #import "AppDelegate.h"
-
-#import "AHTabBarController.h"
+#import "AHExampleListViewController.h"
 
 @implementation AppDelegate
-
--(void)setupMenu
-{
-    AHTabBarController *tabBarController = (AHTabBarController*)self.window.rootViewController;
-    
-    /******* PURUS *******/
-    AHTabView *purus = [AHTabView new];
-    [purus setImage:[UIImage imageNamed:@"persondot"]];
-    [purus setTitle:@"Purus"];
-    
-    AHSubitemView *pFirst = [AHSubitemView new];
-    [pFirst setImage:[UIImage imageNamed:@"persondot"]];
-    [pFirst setTitle:@"First"];
-    [pFirst setViewControllerIdentifier:@"PurusFirst"];
-    [purus addSubitem:pFirst];
-    
-    AHSubitemView *pSecond = [AHSubitemView new];
-    [pSecond setImage:[UIImage imageNamed:@"newspaper"]];
-    [pSecond setTitle:@"Second"];
-    [pSecond setViewControllerIdentifier:@"PurusSecond"];
-    [purus addSubitem:pSecond];
-    
-    /******* FRINGILLA *******/
-    AHTabView *fringilla = [AHTabView new];
-    [fringilla setImage:[UIImage imageNamed:@"receipt"]];
-    [fringilla setTitle:@"Fringilla"];
-    
-    AHSubitemView *fFirst = [AHSubitemView new];
-    [fFirst setImage:[UIImage imageNamed:@"photos"]];
-    [fFirst setTitle:@"First"];
-    [fFirst setViewControllerIdentifier:@"FringillaFirst"];
-    [fringilla addSubitem:fFirst];
-    
-    AHSubitemView *fSecond = [AHSubitemView new];
-    [fSecond setImage:[UIImage imageNamed:@"tv"]];
-    [fSecond setTitle:@"Second"];
-    [fSecond setViewControllerIdentifier:@"FringillaSecond"];
-    [fringilla addSubitem:fSecond];
-    
-    AHSubitemView *fThird = [AHSubitemView new];
-    [fThird setImage:[UIImage imageNamed:@"user"]];
-    [fThird setTitle:@"Third"];
-    [fThird setViewControllerIdentifier:@"FringillaThird"];
-    [fringilla addSubitem:fThird];
-    
-    /******* IPSUM *******/
-    AHTabView *ipsum = [AHTabView new];
-    [ipsum setImage:[UIImage imageNamed:@"user"]];
-    [ipsum setTitle:@"Ipsum"];
-    
-    AHSubitemView *iFirst = [AHSubitemView new];
-    [iFirst setImage:[UIImage imageNamed:@"photos"]];
-    [iFirst setTitle:@"First"];
-    [iFirst setViewControllerIdentifier:@"IpsumFirst"];
-    [ipsum addSubitem:iFirst];
-    
-    //Don't forget to add your AHTabView instances to the AHTabBarController!
-    [tabBarController.tabs addObjectsFromArray:@[purus, fringilla, ipsum]];
-}
 
 #pragma mark - App lifecycle
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
-    [self setupMenu];
+    AHExampleListViewController *baseViewController = [[AHExampleListViewController alloc] init];
+    UINavigationController *navigationController =
+    [[UINavigationController alloc] initWithRootViewController:baseViewController];
+    
+    self.window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
+    self.window.rootViewController = navigationController;
+    [self.window makeKeyAndVisible];
+    
     return YES;
 }
 							

--- a/AHTabBarController/Base.lproj/Main.storyboard
+++ b/AHTabBarController/Base.lproj/Main.storyboard
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6254" systemVersion="14B25" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="vXZ-lx-hvc">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10116" systemVersion="15A284" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="vXZ-lx-hvc">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6247"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
     </dependencies>
     <scenes>
-        <!--Tab Bar Controller-->
+        <!--Storyboard Example View Controller-->
         <scene sceneID="ufC-wZ-h7g">
             <objects>
-                <viewController storyboardIdentifier="AHTabBarController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="vXZ-lx-hvc" customClass="AHTabBarController" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="AHStoryboardExampleViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="vXZ-lx-hvc" customClass="AHStoryboardExampleViewController" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="jyV-Pf-zRb"/>
                         <viewControllerLayoutGuide type="bottom" id="2fi-mo-0CV"/>
@@ -26,7 +26,7 @@
         <!--Purus-->
         <scene sceneID="GuF-GK-Rj0">
             <objects>
-                <viewController id="Tyg-rL-fGC" customClass="ViewController" sceneMemberID="viewController">
+                <viewController id="Tyg-rL-fGC" customClass="AHExampleViewController" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="eG1-KE-m3V"/>
                         <viewControllerLayoutGuide type="bottom" id="O5b-sb-Luj"/>
@@ -296,9 +296,4 @@
             <point key="canvasLocation" x="3355" y="-554"/>
         </scene>
     </scenes>
-    <simulatedMetricsContainer key="defaultSimulatedMetrics">
-        <simulatedStatusBarMetrics key="statusBar"/>
-        <simulatedOrientationMetrics key="orientation"/>
-        <simulatedScreenMetrics key="destination" type="retina4"/>
-    </simulatedMetricsContainer>
 </document>


### PR DESCRIPTION
Shouldn’t break code for existing implementations.  Opens up a way to
override the default storyboard implementation in AHTabBarController by
overriding viewControllerForSubItem returning a view controller created
in code.

Let me know if you have suggestions for a more appropriate implementation.
